### PR TITLE
[0.11.x] Update compatibility for draw-steel 0.11.x and Foundry 13.351

### DIFF
--- a/module.json
+++ b/module.json
@@ -4,21 +4,26 @@
   "description": "Act 2 of the Svellheim campaign for the Draw Steel system. Contains montage tests, negotiation tests, player journals, and director journals for The Deep Road storyline.",
   "url": "https://github.com/bruceamoser/Svellheim-Act2",
   "manifest": "https://github.com/bruceamoser/Svellheim-Act2/releases/latest/download/module.json",
-  "download": "https://github.com/bruceamoser/Svellheim-Act2/releases/download/v0.1.11/svellheim-act2-v0.1.11.zip",
-  "version": "0.1.11",
+  "download": "https://github.com/bruceamoser/Svellheim-Act2/releases/download/v0.1.12/svellheim-act2-v0.1.12.zip",
+  "version": "0.1.12",
   "authors": [
     {
       "name": "Bruce A. Moser"
     }
   ],
   "compatibility": {
-    "minimum": "11",
-    "verified": "13"
+    "minimum": "13",
+    "verified": "13.351"
   },
   "relationships": {
     "systems": [
       {
-        "id": "draw-steel"
+        "id": "draw-steel",
+        "type": "system",
+        "compatibility": {
+          "minimum": "0.9.0",
+          "verified": "0.11.1"
+        }
       }
     ],
     "requires": [


### PR DESCRIPTION
## Summary

Updates compatibility declarations for draw-steel 0.11.x.

## Changes

- Foundry minimum `11`->`13`, verified `13`->`13.351`
- Added draw-steel system compat: minimum `0.9.0`, verified `0.11.1`
- Bumped version to `0.1.12`

Closes #6
